### PR TITLE
fix: fixed auth publish workflow files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish Package to npm on Tag
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # vX.Y.Z 형식의 태그가 푸시될 때 실행
+      - "[0-9]+.[0-9]+.[0-9]+" # X.Y.Z 형식의 태그가 푸시될 때 실행
 
 jobs:
   publish:
@@ -26,7 +26,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/bundle/kr-corekit.js",
+  "config": {
+    "tag-version-prefix": ""
+  },
   "sideEffects": false,
   "exports": {
     ".": {


### PR DESCRIPTION
### Description
- 태그가 푸쉬될 때 `v` prefix를 제거할 수 있도록 설정 파일을 추가했어요
- frozen-lockfile 설정이 붙어있어 `npm ci` 처럼 동작할 때, pnpm-lock.yaml과 package.json의 의존성이 달라 버젼을 맞춰주는 작업을 진행했어요
<img width="1151" height="803" alt="스크린샷 2025-10-25 오후 8 12 46" src="https://github.com/user-attachments/assets/3bbd843c-b53c-4486-95cc-6b72da45cedb" />